### PR TITLE
修復install安裝程式未能成功安裝bug

### DIFF
--- a/install-wcl.sh
+++ b/install-wcl.sh
@@ -4,6 +4,7 @@ copy_file(){ # copy 程式檔案目錄到bin 和 opt
     cp ./wall-color-tool.sh /usr/bin
     cp ./wcl-help-en.sh /opt/wcl
     cp ./wcl-help-cn.sh /opt/wcl
+    mv ./usr/bin/wall-color-tool.sh ./usr/bin/wcl
 }
 
 if [[ -d /usr/bin/wall-color-tool.sh || -d /opt/wcl ]]; then # 檢索/usr/bin 和/opt/是否有wcl


### PR DESCRIPTION
修復由於一開始的install.sh文件將wall-color-tool.sh移動到/usr/bin/内未更改名稱，導致文件名稱不符合，所以無法使用wcl指令